### PR TITLE
feat: add real-time status indicators for stack and container operations

### DIFF
--- a/DockTUI/ui/widgets/headers.py
+++ b/DockTUI/ui/widgets/headers.py
@@ -417,6 +417,7 @@ class StackHeader(Static):
         total: int,
         can_recreate: bool = True,
         has_compose_file: bool = True,
+        operation_status: Optional[str] = None,
     ):
         """Initialize the stack header.
 
@@ -428,6 +429,7 @@ class StackHeader(Static):
             total: Total number of containers
             can_recreate: Whether the stack can be recreated (compose file accessible)
             has_compose_file: Whether a compose file path is defined
+            operation_status: Optional operation status (e.g., "Starting...", "Stopping...")
         """
         super().__init__("")
         self.stack_name = stack_name
@@ -438,6 +440,7 @@ class StackHeader(Static):
         self.config_file = config_file
         self.can_recreate = can_recreate
         self.has_compose_file = has_compose_file
+        self.operation_status = operation_status
         self.can_focus = True
         self._last_click_time = 0
         self._update_content()
@@ -450,6 +453,11 @@ class StackHeader(Static):
         status = Text.assemble(
             running_text, ", ", exited_text, f", Total: {self.total}"
         )
+
+        # Add operation status if present
+        if self.operation_status:
+            status.append("  ")
+            status.append(Text(f"[{self.operation_status}]", style="italic cyan"))
 
         # Add indicator if recreate is not available
         recreate_indicator = ""
@@ -480,6 +488,15 @@ class StackHeader(Static):
     def toggle(self) -> None:
         """Toggle the expanded/collapsed state of the stack."""
         self.expanded = not self.expanded
+        self._update_content()
+
+    def set_operation_status(self, status: Optional[str]) -> None:
+        """Update the operation status and refresh the display.
+
+        Args:
+            status: The operation status to display, or None to clear
+        """
+        self.operation_status = status
         self._update_content()
 
     def on_click(self) -> None:

--- a/tests/ui/managers/test_stack_manager.py
+++ b/tests/ui/managers/test_stack_manager.py
@@ -30,6 +30,8 @@ class TestStackManager(unittest.TestCase):
         self.parent.stacks_container.children = []
         self.parent._is_updating = False
         self.parent._status_overrides = {}
+        self.parent._stack_status_overrides = {}
+        self.parent.get_stack_status = Mock(return_value=None)
         self.parent.screen = None
 
         self.manager = StackManager(self.parent)
@@ -71,7 +73,8 @@ class TestStackManager(unittest.TestCase):
             "test-stack",
             "/path/to/compose.yml",
             2, 1, 3,
-            True, True
+            True, True,
+            None  # operation_status
         )
 
         # Check table was created


### PR DESCRIPTION
- Show operation status (Starting..., Stopping...) directly on stack headers
- Display transition states on individual containers during stack operations
- Execute stack commands in background threads for non-blocking UI
- Auto-expand stacks to show container progress during operations
- Add smart status filtering based on container state
- Implement time-based expiration for long-running operation indicators