### PR TITLE
feat: dockerize application with Docker Hub integration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,38 @@
+# Git
+.git/
+.gitignore
+
+# Python cache
+__pycache__/
+*.pyc
+.pytest_cache/
+
+# Virtual environments
+venv/
+.venv/
+env/
+.env
+
+# IDE
+.vscode/
+.idea/
+*.swp
+
+# Logs and temp files
+logs/
+*.log
+*.tmp
+
+# Tests (not needed at runtime)
+tests/
+
+# Documentation
+*.md
+
+# Development files
+Makefile
+.pre-commit-config.yaml
+scripts-dev/
+
+# OS files
+.DS_Store

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,73 @@
+name: Docker Publish
+
+on:
+  push:
+    tags:
+      - 'v*'  # Trigger on version tags
+  workflow_dispatch:  # Allow manual trigger
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: dialmaster/docktui
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            # Set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
+            # Set version tag from git tag
+            type=ref,event=tag
+            # Set version without v prefix (e.g., 1.0.0 from v1.0.0)
+            type=semver,pattern={{version}}
+            # Set major.minor version (e.g., 1.0 from v1.0.0)
+            type=semver,pattern={{major}}.{{minor}}
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  update-docker-hub-description:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Update Docker Hub Description
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ env.IMAGE_NAME }}
+          short-description: "Terminal UI for real-time Docker container monitoring and management"
+          readme-filepath: ./README.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
       contents: write      # needed for tag + release
       pull-requests: write # needed for release PR
       issues: write        # needed for PR labels
+    outputs:
+      release_created: ${{ steps.rp.outputs.release_created }}
+      tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -27,3 +30,56 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+  
+  docker-build:
+    needs: release
+    if: ${{ needs.release.outputs.release_created }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release.outputs.tag_name }}
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: dialmaster/docktui
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ needs.release.outputs.tag_name }}
+            type=semver,pattern={{version}},value=${{ needs.release.outputs.tag_name }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.release.outputs.tag_name }}
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      
+      - name: Update Docker Hub Description
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: dialmaster/docktui
+          short-description: "Terminal UI for real-time Docker container monitoring and management"
+          readme-filepath: ./README.md

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -126,16 +126,29 @@ DockTUI/
 - Docker Engine installed and running
 - Poetry (Python package manager)
 
-### Setting Up Development Environment
+### Quick Start for Development
 
 ```bash
 # Clone the repository
 git clone https://github.com/dialmaster/DockTUI.git
 cd DockTUI
 
+# Run in development mode (automatically handles Poetry setup)
+./scripts-dev/start-dev.sh
+```
+
+The `scripts-dev/start-dev.sh` script automatically:
+- Checks for Poetry installation
+- Installs dependencies
+- Runs DockTUI in the local Python environment
+
+### Manual Development Setup
+
+```bash
+# Install Poetry if not already installed
+pip install poetry
+
 # Install dependencies
-make install
-# or
 poetry install
 
 # Install pre-commit hooks (recommended)
@@ -143,22 +156,48 @@ poetry run pre-commit install
 
 # Activate the virtual environment
 poetry shell
+
+# Run DockTUI
+python -m DockTUI
 ```
 
 ### Running in Development
 
 ```bash
-# Run normally
+# Using scripts-dev/start-dev.sh
+./scripts-dev/start-dev.sh           # Run normally
+./scripts-dev/start-dev.sh -d        # Run with debug logging
+./scripts-dev/start-dev.sh -h        # Show help
+
+# Or manually after poetry shell
 python -m DockTUI
 
-# Run with debug logging
+# With debug logging
 export DOCKTUI_DEBUG=1
 python -m DockTUI
-# or
-./start.sh -d
 ```
 
 Debug logs are written to `./logs/DockTUI_debug.log`.
+
+### Testing Docker Builds Locally
+
+To test your changes in a Docker container before pushing:
+
+```bash
+# Build local Docker image
+./scripts-dev/build-local.sh
+
+# Run the locally built image
+./scripts-dev/start-local.sh
+./scripts-dev/start-local.sh -d  # With debug logging
+```
+
+### Development Scripts
+
+All development scripts are in the `scripts-dev/` directory:
+- `start-dev.sh` - Run DockTUI with Poetry (Python environment)
+- `build-local.sh` - Build Docker image locally for testing
+- `start-local.sh` - Run the locally built Docker image
 
 ## Code Quality and Testing
 

--- a/DockTUI/docker_mgmt/manager.py
+++ b/DockTUI/docker_mgmt/manager.py
@@ -99,6 +99,9 @@ class DockerManager:
         try:
             containers = self.client.containers.list(all=True)
 
+            # Filter out the DockTUI container itself to prevent users from stopping their own session
+            containers = [c for c in containers if c.name != "docktui-app"]
+
             for container in containers:
                 try:
                     project = container.labels.get(
@@ -168,6 +171,9 @@ class DockerManager:
 
             # Get all running containers
             containers = self.client.containers.list(filters={"status": "running"})
+
+            # Filter out the DockTUI container
+            containers = [c for c in containers if c.name != "docktui-app"]
             logger.debug(f"Found {len(containers)} running containers")
 
             if not containers:
@@ -737,6 +743,8 @@ class DockerManager:
             def fetch_containers():
                 nonlocal all_containers
                 all_containers = self.client.containers.list(all=True)
+                # Filter out the DockTUI container
+                all_containers = [c for c in all_containers if c.name != "docktui-app"]
 
             # Create threads for concurrent fetching
             image_thread = threading.Thread(target=fetch_images)

--- a/DockTUI/utils/clipboard.py
+++ b/DockTUI/utils/clipboard.py
@@ -17,6 +17,17 @@ def copy_to_clipboard_sync(text):
         "yes",
     ]
 
+    # Check for clipboard file mount FIRST (container preferred method)
+    clipboard_file = os.environ.get("DOCKTUI_CLIPBOARD_FILE")
+    if clipboard_file and in_container:
+        try:
+            with open(clipboard_file, "w") as f:
+                f.write(text)
+            logger.info(f"Wrote to clipboard file: {clipboard_file}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to write to clipboard file {clipboard_file}: {e}")
+
     # If not in container, try pyperclip first (local environments)
     if not in_container:
         try:
@@ -46,9 +57,8 @@ def copy_to_clipboard_sync(text):
     except Exception as e:
         logger.debug(f"xclip failed: {e}")
 
-    # Check for clipboard file mount (container alternative)
-    clipboard_file = os.environ.get("DOCKTUI_CLIPBOARD_FILE")
-    if clipboard_file:
+    # Try clipboard file as fallback even if not in container
+    if clipboard_file and not in_container:
         try:
             with open(clipboard_file, "w") as f:
                 f.write(text)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,63 @@
+# Multi-stage build for DockTUI
+FROM python:3.12-slim AS builder
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    gcc \
+    g++ \
+    make \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install poetry
+RUN pip install --no-cache-dir poetry==1.7.1
+
+# Set working directory
+WORKDIR /app
+
+# Copy dependency files first for better caching
+COPY pyproject.toml poetry.lock* ./
+
+# Configure poetry to not create virtual environment
+RUN poetry config virtualenvs.create false
+
+# Install dependencies
+RUN poetry install --no-interaction --no-ansi --no-root
+
+# Copy the application code
+COPY DockTUI ./DockTUI
+
+# Install the application
+RUN poetry install --no-interaction --no-ansi
+
+# Final stage
+FROM python:3.12-slim
+
+# No runtime dependencies needed - we use file-based clipboard
+
+# Create non-root user
+RUN useradd -m -u 1000 docktui
+
+# Set working directory
+WORKDIR /app
+
+# Copy installed packages from builder
+COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
+
+# Copy application
+COPY --from=builder /app/DockTUI ./DockTUI
+
+# Create directories for config and logs
+RUN mkdir -p /app/logs /config && \
+    chown -R docktui:docktui /app /config
+
+# Switch to non-root user
+USER docktui
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1
+ENV TERM=xterm-256color
+ENV DOCKTUI_IN_CONTAINER=1
+
+# Entry point
+ENTRYPOINT ["python", "-m", "DockTUI"]

--- a/README.md
+++ b/README.md
@@ -25,46 +25,47 @@ DockTUI is a terminal user interface (TUI) that provides a real-time dashboard f
 
 ### Prerequisites
 
-- Python 3.12 or higher
 - Docker Engine installed and running
 - Docker Compose v2 (the `docker compose` command)
 - Unix-like terminal (Linux, macOS, or WSL2 on Windows)
 
+> **Note:** No Python or other dependencies required! DockTUI runs entirely in Docker.
+
 ### Quick Start
 
 ```bash
-# Clone the repository
+# Option 1: Run directly (no clone needed)
+curl -sSL https://raw.githubusercontent.com/dialmaster/DockTUI/main/start.sh | bash
+
+# Option 2: Clone and run
 git clone https://github.com/dialmaster/DockTUI.git
 cd DockTUI
-
-# Run DockTUI (automatically installs dependencies)
 ./start.sh
 ```
 
-That's it! The `start.sh` script handles everything for you.
+That's it! The script automatically pulls and runs DockTUI from Docker Hub.
 
 ### Start Options
 
 ```bash
-./start.sh           # Run normally
+./start.sh           # Run latest version
 ./start.sh -d        # Run with debug logging
+./start.sh -u        # Update to latest version
+./start.sh -v 1.0.0  # Run specific version
 ./start.sh -h        # Show help
 ```
 
-### Manual Installation
+### Features of Dockerized Setup
 
-If you prefer to install manually:
+- **Zero build time** - Pre-built images from Docker Hub
+- **Automatic updates** - Just use `-u` flag to get latest version
+- **Multi-platform** - Works on AMD64 and ARM64 (including M1 Macs)
+- **Version control** - Pin to specific versions with `-v`
+- **Full functionality** - All features work including clipboard support
 
-```bash
-# Install Poetry if not already installed
-pip install poetry
+### For Developers
 
-# Install dependencies
-poetry install
-
-# Run DockTUI
-poetry run DockTUI
-```
+If you want to contribute or run DockTUI without Docker, see [DEVELOPMENT.md](DEVELOPMENT.md) for Python/Poetry setup instructions.
 
 ## Usage
 
@@ -181,24 +182,11 @@ export DOCKTUI_LOG_SINCE=1h
 
 ## Clipboard Support
 
-DockTUI supports copying log text to your clipboard:
+DockTUI automatically handles clipboard integration. Selected text from logs can be copied to your system clipboard with:
+- Click and drag to select text
+- Right click to copy
 
-### Local Setup
-Works automatically on most systems. For Linux/WSL2, install `xclip`:
-
-```bash
-sudo apt-get install xclip
-```
-
-### Running in Docker
-When running DockTUI inside a container, use file-based clipboard:
-
-```bash
-docker run -v /tmp/clipboard:/tmp/clipboard \
-           -e DOCKTUI_IN_CONTAINER=1 \
-           -e DOCKTUI_CLIPBOARD_FILE=/tmp/clipboard/clipboard.txt \
-           DockTUI
-```
+The dockerized version automatically syncs the clipboard with your host system.
 
 ## Troubleshooting
 
@@ -213,8 +201,8 @@ docker run -v /tmp/clipboard:/tmp/clipboard \
 - Update Docker to get the integrated `docker compose` command
 
 **Clipboard not working**
-- Linux/WSL2: Install `xclip` with `sudo apt-get install xclip`
-- Containers: Set up file-based clipboard as shown above
+- Ensure your host system has a clipboard tool (xclip, pbcopy, etc.)
+- The Docker version handles clipboard sync automatically
 
 **Performance issues with many containers**
 - Adjust log settings in configuration
@@ -226,9 +214,6 @@ Enable detailed logging to troubleshoot issues:
 
 ```bash
 ./start.sh -d
-# or
-export DOCKTUI_DEBUG=1
-python -m DockTUI
 ```
 
 Debug logs are saved to `./logs/DockTUI_debug.log`.

--- a/scripts-dev/build-local.sh
+++ b/scripts-dev/build-local.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Build DockTUI Docker image locally for development testing
+# This script builds the image from local source code
+
+set -e  # Exit on any error
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Configuration
+IMAGE_NAME="docktui:local"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Show help
+if [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]]; then
+    echo "Usage: $0"
+    echo ""
+    echo "Builds DockTUI Docker image locally for development testing."
+    echo "The image will be tagged as 'docktui:local'"
+    exit 0
+fi
+
+# Check if Docker is installed and running
+if ! command -v docker &> /dev/null; then
+    echo -e "${RED}Error: Docker is not installed. Please install Docker first.${NC}"
+    exit 1
+fi
+
+if ! docker info &> /dev/null; then
+    echo -e "${RED}Error: Docker daemon is not running. Please start Docker.${NC}"
+    exit 1
+fi
+
+# Build the Docker image
+echo -e "${GREEN}Building DockTUI Docker image locally...${NC}"
+cd "$PROJECT_DIR"
+
+if docker build -t "$IMAGE_NAME" .; then
+    echo -e "${GREEN}✓ Docker image built successfully!${NC}"
+    echo -e "${GREEN}Image tagged as: $IMAGE_NAME${NC}"
+    echo ""
+    echo "To run the locally built image, use:"
+    echo "  ./scripts-dev/start-local.sh"
+else
+    echo -e "${RED}Failed to build Docker image${NC}"
+    exit 1
+fi

--- a/scripts-dev/start-dev.sh
+++ b/scripts-dev/start-dev.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Start script for DockTUI
+# This script activates the poetry environment and runs the application
+
+set -e  # Exit on any error
+
+# Parse command line arguments
+DEBUG_MODE=false
+HELP=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -d|--debug)
+            DEBUG_MODE=true
+            shift
+            ;;
+        -h|--help)
+            HELP=true
+            shift
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Use -h or --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+# Show help if requested
+if [[ "$HELP" == true ]]; then
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  -d, --debug    Enable debug mode with detailed logging"
+    echo "  -h, --help     Show this help message"
+    echo ""
+    echo "Examples:"
+    echo "  $0              # Run normally"
+    echo "  $0 -d           # Run with debug logging enabled"
+    exit 0
+fi
+
+# Check if poetry is installed
+if ! command -v poetry &> /dev/null; then
+    echo "Error: Poetry is not installed. Please install poetry first:"
+    echo "  pip install poetry"
+    exit 1
+fi
+
+# Check if pyproject.toml exists
+if [[ ! -f "pyproject.toml" ]]; then
+    echo "Error: pyproject.toml not found. Make sure you're in the DockTUI directory."
+    exit 1
+fi
+
+# Install dependencies if needed
+echo "Ensuring dependencies are installed..."
+poetry install
+
+# Set debug environment variable if requested
+if [[ "$DEBUG_MODE" == true ]]; then
+    echo "Starting DockTUI in debug mode..."
+    echo "Debug logs will be written to ./logs/DockTUI.log"
+    export DOCKTUI_DEBUG=1
+else
+    echo "Starting DockTUI..."
+fi
+
+# Run the application using poetry
+poetry run python -m DockTUI


### PR DESCRIPTION
- Add Dockerfile with multi-stage build for minimal image size
- Create Docker Hub publishing workflow integrated with releases
- Update start.sh to pull from Docker Hub instead of building locally
- Move development scripts to scripts-dev/ directory
- Add container filtering to hide DockTUI from its own UI
- Implement file-based clipboard sync for container environment
- Update documentation to reflect Docker-first approach

Users can now run DockTUI with zero dependencies using pre-built images from Docker Hub. Supports version pinning, multi-platform (AMD64/ARM64), and automatic updates with -u flag.