### PR TITLE
fix: make status changes more responsive

### DIFF
--- a/DockTUI/ui/actions/refresh_actions.py
+++ b/DockTUI/ui/actions/refresh_actions.py
@@ -219,6 +219,16 @@ class RefreshActions:
                                 if hasattr(self, "refresh_bindings"):
                                     self.refresh_bindings()
                             break
+                elif item_type == "stack":
+                    # For stacks, check if any container status changed
+                    # This is important so log pane can refresh when containers in the stack change status
+                    if item_id in stacks:
+                        stack_info = stacks[item_id]
+                        # Force a log pane update with the latest stack data
+                        # The log pane will re-stream logs from all containers in the stack
+                        self.log_pane.update_selection(
+                            "stack", item_id, stack_info, force_restart=False
+                        )
                 elif item_type == "image":
                     # Check if selected image's usage status changed
                     if self.container_list.image_manager.selected_image_data:

--- a/DockTUI/ui/widgets/headers.py
+++ b/DockTUI/ui/widgets/headers.py
@@ -438,7 +438,6 @@ class StackHeader(Static):
         total: int,
         can_recreate: bool = True,
         has_compose_file: bool = True,
-        operation_status: Optional[str] = None,
     ):
         """Initialize the stack header.
 
@@ -450,7 +449,6 @@ class StackHeader(Static):
             total: Total number of containers
             can_recreate: Whether the stack can be recreated (compose file accessible)
             has_compose_file: Whether a compose file path is defined
-            operation_status: Optional operation status (e.g., "Starting...", "Stopping...")
         """
         super().__init__("")
         self.stack_name = stack_name
@@ -461,7 +459,6 @@ class StackHeader(Static):
         self.config_file = config_file
         self.can_recreate = can_recreate
         self.has_compose_file = has_compose_file
-        self.operation_status = operation_status
         self.can_focus = True
         self._last_click_time = 0
         self._update_content()
@@ -474,11 +471,6 @@ class StackHeader(Static):
         status = Text.assemble(
             running_text, ", ", exited_text, f", Total: {self.total}"
         )
-
-        # Add operation status if present
-        if self.operation_status:
-            status.append("  ")
-            status.append(Text(f"[{self.operation_status}]", style="italic cyan"))
 
         # Add indicator if recreate is not available
         recreate_indicator = ""
@@ -509,15 +501,6 @@ class StackHeader(Static):
     def toggle(self) -> None:
         """Toggle the expanded/collapsed state of the stack."""
         self.expanded = not self.expanded
-        self._update_content()
-
-    def set_operation_status(self, status: Optional[str]) -> None:
-        """Update the operation status and refresh the display.
-
-        Args:
-            status: The operation status to display, or None to clear
-        """
-        self.operation_status = status
         self._update_content()
 
     def on_click(self) -> None:

--- a/tests/docker_mgmt/test_manager.py
+++ b/tests/docker_mgmt/test_manager.py
@@ -657,6 +657,8 @@ class TestDockerManager:
                 mock_process = Mock()
                 mock_process.stdout = Mock()
                 mock_process.stderr = Mock()
+                mock_process.communicate = Mock(return_value=("Success", ""))
+                mock_process.returncode = 0
                 mock_popen.return_value = mock_process
 
                 result = manager.execute_stack_command("stack1", "/path/to/compose.yml", "recreate")
@@ -678,6 +680,8 @@ class TestDockerManager:
             mock_process = Mock()
             mock_process.stdout = Mock()
             mock_process.stderr = Mock()
+            mock_process.communicate = Mock(return_value=("Success", ""))
+            mock_process.returncode = 0
             mock_popen.return_value = mock_process
 
             result = manager.execute_stack_command("stack1", "/path/to/compose.yml", "down")
@@ -739,6 +743,8 @@ class TestDockerManager:
             mock_process = Mock()
             mock_process.stdout = Mock()
             mock_process.stderr = Mock()
+            mock_process.communicate = Mock(return_value=("Success", ""))
+            mock_process.returncode = 0
             mock_popen.return_value = mock_process
 
             result = manager.execute_stack_command("stack1", "/path/to/compose.yml", "down:remove_volumes")

--- a/tests/ui/actions/test_docker_actions.py
+++ b/tests/ui/actions/test_docker_actions.py
@@ -147,7 +147,6 @@ class TestDockerActions:
         app.container_list.update_container_status.assert_called_once_with(
             "test-container", "starting..."
         )
-        app.refresh.assert_called_once()
 
         # Verify thread was started
         mock_thread.assert_called_once()
@@ -172,7 +171,6 @@ class TestDockerActions:
         app.container_list.update_container_status.assert_called_once_with(
             "test-container", "stopping..."
         )
-        app.refresh.assert_called_once()
 
         # Verify thread was started
         mock_thread.assert_called_once()
@@ -217,18 +215,10 @@ class TestDockerActions:
 
         app.execute_docker_command("start")
 
-        # Check that set_stack_status was called instead of error_display
-        app.container_list.set_stack_status.assert_called_once_with(
-            "my-stack", "Starting..."
-        )
-        
         # Check that set_stack_containers_status was called
         app.container_list.set_stack_containers_status.assert_called_once_with(
             "my-stack", "start"
         )
-        
-        # Check that refresh was called to update the UI
-        app.refresh.assert_called_once()
         
         # Check that a timer was set to call action_refresh
         assert len(app._timers) == 1
@@ -256,18 +246,10 @@ class TestDockerActions:
 
         app.execute_docker_command("down")
 
-        # Check that set_stack_status was called instead of error_display
-        app.container_list.set_stack_status.assert_called_once_with(
-            "my-stack", "Taking down..."
-        )
-        
         # Check that set_stack_containers_status was called
         app.container_list.set_stack_containers_status.assert_called_once_with(
             "my-stack", "down"
         )
-        
-        # Check that refresh was called to update the UI
-        app.refresh.assert_called_once()
         
         # Check that a timer was set to call action_refresh
         assert len(app._timers) == 1
@@ -438,9 +420,10 @@ class TestDockerActions:
 
         app.execute_docker_command("start")
 
-        # Check that set_stack_status was called
-        app.container_list.set_stack_status.assert_called_once_with(
-            "my-stack", "Starting..."
+        # Stack status is no longer set directly, only container statuses
+        # Check that set_stack_containers_status was called  
+        app.container_list.set_stack_containers_status.assert_called_once_with(
+            "my-stack", "start"
         )
         
         # The actual error would be shown from the background thread


### PR DESCRIPTION
- Add immediate UI updates when container status changes (start/stop/restart/recreate)                                     - Update log pane to reflect container status changes in real-time
- Force container recreation with --force-recreate flag for better reliability
- Add background monitoring for stack recreate operations
- Improve status transitions for stack operations affecting multiple containers
- Remove unnecessary stack-level status tracking in favor of container-level updates