### PR TITLE
feat: add container status colors and improve log copy shortcut

### DIFF
--- a/DockTUI/app.py
+++ b/DockTUI/app.py
@@ -332,6 +332,8 @@ class DockTUIApp(App, DockerActions, RefreshActions):
             return
 
         item_type, item_id = self.container_list.selected_item
+        # Ensure item_id is a string (might be ContainerText from UI)
+        item_id = str(item_id)
 
         # Only allow removing containers, not stacks
         if item_type != "container":
@@ -365,6 +367,8 @@ class DockTUIApp(App, DockerActions, RefreshActions):
             return
 
         item_type, item_id = self.container_list.selected_item
+        # Ensure item_id is a string (might be ContainerText from UI)
+        item_id = str(item_id)
 
         # Get stack name for the modal
         stack_name = "unknown"
@@ -418,6 +422,8 @@ class DockTUIApp(App, DockerActions, RefreshActions):
             return
 
         item_type, item_id = self.container_list.selected_item
+        # Ensure item_id is a string (might be ContainerText from UI)
+        item_id = str(item_id)
 
         # Handle container removal
         if item_type == "container":
@@ -474,6 +480,8 @@ class DockTUIApp(App, DockerActions, RefreshActions):
             return
 
         item_type, item_id = self.container_list.selected_item
+        # Ensure item_id is a string (might be ContainerText from UI)
+        item_id = str(item_id)
         if item_type != "image":
             self.error_display.update("Selected item is not an image")
             return

--- a/DockTUI/ui/actions/docker_actions.py
+++ b/DockTUI/ui/actions/docker_actions.py
@@ -80,6 +80,8 @@ class DockerActions:
         """
         # Note: Validation is now done in is_action_applicable before calling this method
         item_type, item_id = self.container_list.selected_item
+        # Ensure item_id is a string (might be ContainerText from UI)
+        item_id = str(item_id)
         success = False
 
         # Track recreate operations so we can update log pane after refresh
@@ -282,6 +284,8 @@ class DockerActions:
                 return
 
             item_type, item_id = self.container_list.selected_item
+            # Ensure item_id is a string (might be ContainerText from UI)
+            item_id = str(item_id)
             if item_type != "image":
                 self.error_display.update("Selected item is not an image")
                 return
@@ -406,6 +410,8 @@ class DockerActions:
                     return
 
                 item_type, item_id = self.container_list.selected_item
+                # Ensure item_id is a string (might be ContainerText from UI)
+                item_id = str(item_id)
                 if item_type != "volume":
                     self.error_display.update("Selected item is not a volume")
                     with self._volume_operation_lock:

--- a/DockTUI/ui/components/navigation_handler.py
+++ b/DockTUI/ui/components/navigation_handler.py
@@ -65,7 +65,7 @@ class NavigationHandler:
             row = table.cursor_row
             stack_name = self._find_table_stack(table)
             if stack_name:
-                container_id = table.get_cell_at((row, 0))
+                container_id = str(table.get_cell_at((row, 0)))
                 self.container_list.select_container(container_id)
 
     def _handle_table_down(self, table: DataTable) -> None:
@@ -91,7 +91,7 @@ class NavigationHandler:
             row = table.cursor_row
             stack_name = self._find_table_stack(table)
             if stack_name:
-                container_id = table.get_cell_at((row, 0))
+                container_id = str(table.get_cell_at((row, 0)))
                 self.container_list.select_container(container_id)
 
     def _handle_header_up(self, current: StackHeader) -> None:
@@ -107,7 +107,9 @@ class NavigationHandler:
                 prev_table.focus()
                 prev_table.move_cursor(row=prev_table.row_count - 1)
                 # Update selection to the container
-                container_id = prev_table.get_cell_at((prev_table.row_count - 1, 0))
+                container_id = str(
+                    prev_table.get_cell_at((prev_table.row_count - 1, 0))
+                )
                 self.container_list.select_container(container_id)
             else:
                 prev_header.focus()

--- a/DockTUI/ui/containers.py
+++ b/DockTUI/ui/containers.py
@@ -761,7 +761,7 @@ class ContainerList(ContainerListBase):
                 try:
                     row = table.get_row_index(row_key)
                     if row is not None and row < table.row_count:
-                        container_id = table.get_cell_at((row, 0))
+                        container_id = str(table.get_cell_at((row, 0)))
                         self.select_container(container_id)
                 except Exception as e:
                     logger.error(

--- a/tests/ui/managers/test_stack_manager.py
+++ b/tests/ui/managers/test_stack_manager.py
@@ -193,9 +193,13 @@ class TestStackManager(unittest.TestCase):
 
         self.manager.add_container_to_stack("test-stack", container_data)
 
-        # Check PIDs shows as N/A
+        # Check PIDs shows as N/A and status
         args = mock_table.add_row.call_args[0]
-        self.assertEqual(args[6], "N/A")
+        
+        # With the new approach, ContainerText objects are used for all containers
+        # Since we're using ContainerText, we need to convert to string for comparison
+        self.assertEqual(str(args[6]), "N/A")  # PIDs column
+        self.assertEqual(str(args[2]), "exited")  # Status column
 
     def test_add_container_to_stack_status_override(self):
         """Test adding container with status override."""


### PR DESCRIPTION
- Add color indicators for container status (red=exited, green=running, yellow=transitioning)
- Change log copy shortcut from Ctrl+Shift+C to 'c' for better usability
- Implement ContainerText wrapper class for rich text rendering in tables
- Ensure proper string conversion throughout codebase for ContainerText objects